### PR TITLE
fixed issue on katavorio file

### DIFF
--- a/lib/katavorio-0.4.js
+++ b/lib/katavorio-0.4.js
@@ -256,6 +256,7 @@
             if (downAt) {
                 if (!moving) {
                     this.params.events["start"]({el:this.el, pos:posAtDown, e:e, drag:this});
+                    if (!downAt) return;
                     this.mark();
                     moving = true;
                 }


### PR DESCRIPTION
Description:
In a component on which the method draggable has NOT been called:
If an Endpoint created with the method AddEndpoint has been linked to this component, and then has been disabled with the method setEnabled(false) in order to prevent any connections to be dragged from it, the following error occurs, when the user still try to drag a connection from the endpoint:
 Uncaught TypeError: Cannot read property '0' of null katavorio

Fix:
The preview issue has been fixed by adding the line:
if (!downAt) return;
right before the call of the mark() function, in order to ensure the downAt won't be set at null, to prevent any operations requiring the element 0 and 1 of the array downAt, just like fives lines further.