### PR TITLE
Fix - Don't make enumerable changes to Array.prototype

### DIFF
--- a/lib/katavorio-0.13.0.js
+++ b/lib/katavorio-0.13.0.js
@@ -30,16 +30,22 @@
 
     "use strict";
 
-    Array.prototype.suggest = function(item, head) {
-        if (this.indexOf(item) === -1) {
-            head ? this.unshift(item) : this.push(item);
-        }
-    };
+    Object.defineProperty(Array.prototype, 'suggest', {
+        value: function(item, head) {
+            if (this.indexOf(item) === -1) {
+                head ? this.unshift(item) : this.push(item);
+            }
+        },
+        enumerable: false
+    });
 
-    Array.prototype.vanquish = function(item) {
-        var idx = this.indexOf(item);
-        if (idx != -1) this.splice(idx, 1);
-    };
+    Object.defineProperty(Array.prototype, 'vanquish', {
+        value: function(item) {
+            var idx = this.indexOf(item);
+            if (idx != -1) this.splice(idx, 1);
+        },
+        enumerable: false
+    });
 
     var _isString = function(f) {
         return f == null ? false : (typeof f === "string" || f.constructor == String);


### PR DESCRIPTION
Extending prototype without making it non-enumerable will break other scripts.