### PR TITLE
Provide a "SPDX License Expression Syntax" compatible license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     ]
   ],
   "author": "Simon Porritt",
-  "license": "MIT/GPL2",
+  "license": "(MIT OR GPL-2.0)",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
Bintray checks the license string if you upload a package. But the currently provided string isnt correct parseable. Please change it to a parseable version.

See https://docs.npmjs.com/files/package.json#license