### PR TITLE
Issue #513: Fixes setSource for same-element endpoints

### DIFF
--- a/src/anchors.js
+++ b/src/anchors.js
@@ -385,6 +385,27 @@
 
             connection.updateConnectedClass();
         };
+		
+		//
+        // find the entry in an endpoints list for this connection and update the target
+        // endpoint with the current source in the connection
+        //
+        this.updateTargetEndpointSource = function (connection, doNotUpdateConnectedClass) {
+            // find entry for target
+            var tIdx = _ju.findWithFunction(connectionsByElementId[connection.targetId], function (i) {
+                return i[0].id === connection.id;
+            });
+            // update target entry if necessary
+            if (tIdx > -1) {
+                connectionsByElementId[connection.targetId][tIdx][0] = connection;
+                connectionsByElementId[connection.targetId][tIdx][1] = connection.endpoints[0];
+                connectionsByElementId[connection.targetId][tIdx][2] = connection.endpoints[0].anchor.constructor == _jp.DynamicAnchor;
+            }
+            
+            if (!doNotUpdateConnectedClass) {
+                connection.updateConnectedClass();
+            }
+        }
 
         //
         // notification that the connection given has changed source from the originalId to the newId.

--- a/src/anchors.js
+++ b/src/anchors.js
@@ -387,6 +387,8 @@
         };
 
         //
+        // find the entry in an endpoints list for this connection and update
+		// the target endpoint with the current source in the connection
         //
         this.updateTargetEndpointSource = function (connection, doNotUpdateConnectedClass) {
             // find entry for target

--- a/src/anchors.js
+++ b/src/anchors.js
@@ -387,8 +387,6 @@
         };
 
         //
-        // find the entry in an endpoints list for this connection and update
-		// the target endpoint with the current source in the connection
         //
         this.updateTargetEndpointSource = function (connection, doNotUpdateConnectedClass) {
             // find entry for target

--- a/src/anchors.js
+++ b/src/anchors.js
@@ -387,25 +387,6 @@
         };
 
         //
-        //
-        this.updateTargetEndpointSource = function (connection, doNotUpdateConnectedClass) {
-            // find entry for target
-            var tIdx = _ju.findWithFunction(connectionsByElementId[connection.targetId], function (i) {
-                return i[0].id === connection.id;
-            });
-            // update target entry if necessary
-            if (tIdx > -1) {
-                connectionsByElementId[connection.targetId][tIdx][0] = connection;
-                connectionsByElementId[connection.targetId][tIdx][1] = connection.endpoints[0];
-                connectionsByElementId[connection.targetId][tIdx][2] = connection.endpoints[0].anchor.constructor == _jp.DynamicAnchor;
-            }
-            
-            if (!doNotUpdateConnectedClass) {
-                connection.updateConnectedClass();
-            }
-        }		
-		
-        //
         // notification that the connection given has changed source from the originalId to the newId.
         // This involves:
         // 1. removing the connection from the list of connections stored for the originalId

--- a/src/anchors.js
+++ b/src/anchors.js
@@ -387,6 +387,25 @@
         };
 
         //
+        //
+        this.updateTargetEndpointSource = function (connection, doNotUpdateConnectedClass) {
+            // find entry for target
+            var tIdx = _ju.findWithFunction(connectionsByElementId[connection.targetId], function (i) {
+                return i[0].id === connection.id;
+            });
+            // update target entry if necessary
+            if (tIdx > -1) {
+                connectionsByElementId[connection.targetId][tIdx][0] = connection;
+                connectionsByElementId[connection.targetId][tIdx][1] = connection.endpoints[0];
+                connectionsByElementId[connection.targetId][tIdx][2] = connection.endpoints[0].anchor.constructor == _jp.DynamicAnchor;
+            }
+            
+            if (!doNotUpdateConnectedClass) {
+                connection.updateConnectedClass();
+            }
+        }		
+		
+        //
         // notification that the connection given has changed source from the originalId to the newId.
         // This involves:
         // 1. removing the connection from the list of connections stored for the originalId

--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -1374,8 +1374,16 @@
 
         this.setSource = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 0, doNotRepaint);
-            this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
-        };
+            
+			// we only need to do a subset of the sourceChanged work
+            // if only the source endpoint and not the source element has changed
+            if (el.constructor === _jp.Endpoint && p.originalSourceId === p.newSourceId) {
+                // just make sure the cache gets updated
+                this.anchorManager.updateTargetEndpointSource(connection);
+            } else {
+                this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
+            }        
+		};
         this.setTarget = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 1, doNotRepaint);
             this.anchorManager.updateOtherEndpoint(p.originalSourceId, p.originalTargetId, p.newTargetId, connection);

--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -1374,15 +1374,7 @@
 
         this.setSource = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 0, doNotRepaint);
-			
-            // we only need to do a subset of the sourceChanged work
-            // if only the source endpoint and not the source element has changed
-            if (el.constructor === root.jsPlumb.Endpoint && p.originalSourceId === p.newSourceId) {
-                // just make sure the cache gets updated
-                this.anchorManager.updateTargetEndpointSource(connection);
-            } else {
-                this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
-            }
+            this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
         };
         this.setTarget = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 1, doNotRepaint);

--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -1377,7 +1377,7 @@
             
 			// we only need to do a subset of the sourceChanged work
             // if only the source endpoint and not the source element has changed
-            if (el.constructor === _jp.Endpoint && p.originalSourceId === p.newSourceId) {
+            if (p.originalSourceId === p.newSourceId) {
                 // just make sure the cache gets updated
                 this.anchorManager.updateTargetEndpointSource(connection);
             } else {

--- a/src/jsPlumb.js
+++ b/src/jsPlumb.js
@@ -1374,7 +1374,15 @@
 
         this.setSource = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 0, doNotRepaint);
-            this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
+			
+            // we only need to do a subset of the sourceChanged work
+            // if only the source endpoint and not the source element has changed
+            if (el.constructor === root.jsPlumb.Endpoint && p.originalSourceId === p.newSourceId) {
+                // just make sure the cache gets updated
+                this.anchorManager.updateTargetEndpointSource(connection);
+            } else {
+                this.anchorManager.sourceChanged(p.originalSourceId, p.newSourceId, connection);
+            }
         };
         this.setTarget = function (connection, el, doNotRepaint) {
             var p = _set(connection, el, 1, doNotRepaint);

--- a/tests/jsPlumb-tests.js
+++ b/tests/jsPlumb-tests.js
@@ -2519,6 +2519,9 @@ var testSuite = function (renderMode, _jsPlumb) {
         _jsPlumb.setSource(c, ep2);
         equal(c.endpoints[0].original, undefined, "setSource with new endpoint honoured");
 
+		// test that new endpoint is set in connection cache
+		// we do this by checking the target's connection's otherEndpoint
+		equal(_jsPlumb.anchorManager.getConnectionsFor(c.targetId)[0][1].original, undefined, "setSource with new endpoint honoured in connection cache");
     });
 
     test(": _jsPlumb.setSource (element, with makeSource)", function () {

--- a/tests/jsPlumb-tests.js
+++ b/tests/jsPlumb-tests.js
@@ -2517,8 +2517,11 @@ var testSuite = function (renderMode, _jsPlumb) {
         // test that new endpoint is set (different from the case that an element or element id was given)
         c.endpoints[0].original = true;
         _jsPlumb.setSource(c, ep2);
-        equal(c.endpoints[0].original, undefined, "setSource with new endpoint honoured");
-
+        equal(c.endpoints[0].original, undefined, "setSource with new endpoint honoured in connection");
+		
+		// test that new endpoint is set in connection cache as well as on connection
+		// by looking at the connection's target's connection's otherEndpoint
+		equal(_jsPlumb.anchorManager.getConnectionsFor(c.targetId)[0][1].original, undefined, "setSource with new endpoint honoured in connection cache");
     });
 
     test(": _jsPlumb.setSource (element, with makeSource)", function () {

--- a/tests/jsPlumb-tests.js
+++ b/tests/jsPlumb-tests.js
@@ -2517,11 +2517,8 @@ var testSuite = function (renderMode, _jsPlumb) {
         // test that new endpoint is set (different from the case that an element or element id was given)
         c.endpoints[0].original = true;
         _jsPlumb.setSource(c, ep2);
-        equal(c.endpoints[0].original, undefined, "setSource with new endpoint honoured in connection");
-		
-		// test that new endpoint is set in connection cache as well as on connection
-		// by looking at the connection's target's connection's otherEndpoint
-		equal(_jsPlumb.anchorManager.getConnectionsFor(c.targetId)[0][1].original, undefined, "setSource with new endpoint honoured in connection cache");
+        equal(c.endpoints[0].original, undefined, "setSource with new endpoint honoured");
+
     });
 
     test(": _jsPlumb.setSource (element, with makeSource)", function () {


### PR DESCRIPTION
setSource() is now fully implemented for setting a new source endpoint while keeping the same source element. The relevant test has been updated to test that the connection cache as well as the actual connection is updated.