### PR TITLE
Updated the bower version to 2.1.5 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jsPlumb",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "ignore": [
     "demo",
     "dist/apidocs",


### PR DESCRIPTION
I am unable to install version 2.1.5 using bower. Found this could be the reason. Let me know if missing anything obvious